### PR TITLE
removing spamming EOF logging entry from logs

### DIFF
--- a/flyte/commands.go
+++ b/flyte/commands.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 	"github.com/ExpediaGroup/flyte-client/client"
 	"github.com/HotelsDotCom/go-logger"
+	"strings"
 	"time"
 )
 
@@ -57,7 +58,9 @@ func (p pack) getNextAction() *client.Action {
 			if _, ok := err.(client.NotFoundError); ok {
 				logger.Fatal("Pack not found while polling for actions. Exiting.")
 			}
-			logger.Infof("could not take action: %s", err)
+			if !strings.HasSuffix(strings.TrimSpace(err.Error()), "EOF") {
+				logger.Infof("could not take action: %s", err)
+			}
 		}
 		if a == nil || err != nil {
 			time.Sleep(p.pollingFrequency)


### PR DESCRIPTION
Signed-off-by: Dmytro Chukmasov <d.chukmasov@expediagroup.com>

Hi! All packs receive an EOF error and spam it on INFO level to stdout. I propose either to remove it from logs (which is done in PR) or log it to DEBUG level.
<img width="1375" alt="Screenshot 2021-05-13 at 15 59 37" src="https://user-images.githubusercontent.com/35612129/118129578-07956700-b405-11eb-95ef-883b4f3ce0bd.png">
